### PR TITLE
changes to handle updated NS3 core

### DIFF
--- a/model/plc-channel.cc
+++ b/model/plc-channel.cc
@@ -1102,14 +1102,14 @@ PLC_Channel::AddDevice (Ptr<NetDevice> dev)
 	return m_devices.size ();
 }
 
-uint32_t
+std::size_t
 PLC_Channel::GetNDevices (void) const
 {
 	NS_LOG_FUNCTION (this);
 	return m_devices.size ();
 }
 
-Ptr<NetDevice> PLC_Channel::GetDevice  (uint32_t i) const
+Ptr<NetDevice> PLC_Channel::GetDevice  (std::size_t i) const
 {
 	NS_LOG_FUNCTION (this);
 	return m_devices[i];

--- a/model/plc-channel.h
+++ b/model/plc-channel.h
@@ -426,13 +426,13 @@ public:
 	*
 	* This method must be implemented by subclasses.
 	*/
-	uint32_t GetNDevices (void) const;
+    std::size_t GetNDevices (void) const;
 
 	/**
 	 * \param i index of NetDevice to retrieve
 	 * \returns one of the NetDevices connected to this channel.
 	 */
-	Ptr<NetDevice> GetDevice (uint32_t i) const;
+	Ptr<NetDevice> GetDevice (std::size_t i) const;
 
 	/**
 	 * Create PLC_Graph and init transmission channel data structures

--- a/model/plc-mac.h
+++ b/model/plc-mac.h
@@ -188,7 +188,7 @@ protected:
 	Mac48Address m_broadcast_address;
 	Mac48Address m_multicast_address;
 
-	Ptr<DropTailQueue> 	m_txQueue;
+	Ptr<DropTailQueue<Packet>> 	m_txQueue;
 	Ptr<Packet>			m_ackPacket;
 	Ptr<Packet> 		m_rxPacket;
 


### PR DESCRIPTION
Latest NS3 core handling for queued packet dequeuing and peeking is changed.

This PR changes the PLC code for these updates thus allowing it to compile/link with latest NS3.